### PR TITLE
Upgraded to 2.0.1, misc.

### DIFF
--- a/RecipeApi/Program.cs
+++ b/RecipeApi/Program.cs
@@ -1,26 +1,16 @@
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace RecipeApi
 {
-    public class Program
+    class Program
     {
-        public static void Main(string[] args)
-        {
-            CreateHostBuilder(args).Build().Run();
-        }
+        static Task Main(string[] args) => 
+            CreateHostBuilder(args).Build().RunAsync();
 
-        public static IHostBuilder CreateHostBuilder(string[] args) =>
+        static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-                .ConfigureWebHostDefaults(webBuilder =>
-                {
-                    webBuilder.UseStartup<Startup>();
-                });
+                .ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>());
     }
 }

--- a/RecipeApi/RecipeApi.csproj
+++ b/RecipeApi/RecipeApi.csproj
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="IEvangelist.Azure.CosmosRepository" Version="1.0.4" />
+		<PackageReference Include="IEvangelist.Azure.CosmosRepository" Version="2.0.1" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
 	</ItemGroup>
 

--- a/RecipeApi/Startup.cs
+++ b/RecipeApi/Startup.cs
@@ -1,27 +1,18 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Threading.Tasks;
 
 namespace RecipeApi
 {
     public class Startup
     {
-        public Startup(IConfiguration configuration)
-        {
-            Configuration = configuration;
-        }
+        public Startup(IConfiguration configuration) => Configuration = configuration;
 
         public IConfiguration Configuration { get; }
 
@@ -52,15 +43,9 @@ namespace RecipeApi
             }
 
             app.UseHttpsRedirection();
-
             app.UseRouting();
-
             app.UseAuthorization();
-
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapControllers();
-            });
+            app.UseEndpoints(endpoints => endpoints.MapControllers());
         }
     }
 }


### PR DESCRIPTION
Upgraded to 2.0.1, use factory pattern to resolve multiple repositories, general clean up.

- Propagate `ValueTask` usage through controller actions / web API
- Use `readonly` fields instead of `public` get props
- Use new `IRepositoryFactory` to resolve multiple `IRepository<TItem>` instance, less dependencies in .ctor
- General C# clean up
- Added what appeared to be missing `[FromBody]` attrs on `HttpPost` methods
- Removed unused `using` statements
- Deleted 10 lines from `Program.cs` and introduced `Task` returning `Main`
- Used lambda expression bodied members where possible